### PR TITLE
grpc-api-remove-delay

### DIFF
--- a/src/api-server.ts
+++ b/src/api-server.ts
@@ -322,6 +322,14 @@ async function closeTopic(parameters: any, callback: any): Promise<void> {
 
 async function sendMessageToTopic(parameters: any, callback: any): Promise<void> {
     console.log(`sendMessageToTopic ${parameters} `)
+    const key = Buffer.from(encoder.encode(call.request.address));        
+        const address = await getKey(key);
+        console.log("address",address)
+        if (address === null) {
+            throw new Error("RSK Address Unknown");
+        } else {
+            
+        }
     const status: any = await publishToRoom(parameters.request.topic.channelId, parameters.request.message.payload);
 
     callback(status, {});

--- a/src/api-server.ts
+++ b/src/api-server.ts
@@ -78,18 +78,17 @@ async function connectToCommunicationsNode(call: any) {
            
     try {
         const result = await retry(async (context) => {
-        addRskAddressToDHT(call.request.address,libp2p.peerId._idB58String)
+        await addRskAddressToDHT(call.request.address,libp2p.peerId._idB58String)
     }, {
-        delay: 1000,
+        delay: 1200,
         maxAttempts: 3,
-        initialDelay: 3000,
       });
 
 
     } catch (err) {
         console.log(err)
     }
-
+    
     let notificationMsg = {
     }
 
@@ -107,7 +106,6 @@ async function connectToCommunicationsNode(call: any) {
             payload: Buffer.from('connection to server already exists', 'utf8')
         }
     }
-
     call.write(notificationMsg);
 }
 
@@ -321,15 +319,7 @@ async function closeTopic(parameters: any, callback: any): Promise<void> {
 }
 
 async function sendMessageToTopic(parameters: any, callback: any): Promise<void> {
-    console.log(`sendMessageToTopic ${parameters} `)
-    const key = Buffer.from(encoder.encode(call.request.address));        
-        const address = await getKey(key);
-        console.log("address",address)
-        if (address === null) {
-            throw new Error("RSK Address Unknown");
-        } else {
-            
-        }
+    console.log(`sendMessageToTopic ${JSON.stringify(parameters)} `)
     const status: any = await publishToRoom(parameters.request.topic.channelId, parameters.request.message.payload);
 
     callback(status, {});
@@ -346,32 +336,17 @@ async function updateAddress (parameters: any, callback: any): Promise<void> {
 //////////////// Internal Server Functions //////////////////////
 
 async function getKey(key: any): Promise<any> {
-    let value:any = null
-
-    try {
-        value = await retry(async (context) => {
-            let val = null;
-            try {
-                val =  await libp2p.contentRouting.get(key);
-                val = decoder.decode(val)
-                if (val == null) {
-                    return Promise.reject("NO VALUE")
-                }
-                return Promise.resolve(val)
-            } catch (error) {
-                return Promise.reject(error)
+        return await retry(async (context) => {
+            const val =  await libp2p.contentRouting.get(key);
+            if (!val) {
+                throw new Error("Value not found");
             }
+            return decoder.decode(val)
         },
         {
-            delay: 1000,
-            maxAttempts: 3,
-            initialDelay: 3000,
-        });     
-    } catch (err) {
-        console.log(err)
-        return value
-    }
-    return value;
+            delay: 1200,
+            maxAttempts: 3
+        }); 
 
 }
 

--- a/src/protos/api.proto
+++ b/src/protos/api.proto
@@ -43,7 +43,7 @@ service CommunicationsApi {
     rpc CloseTopic (Channel) returns (Void);
 
     //Send Message to Specified Topic
-    rpc SendMessageToTopic(PublishPayload) returns (Void);
+    rpc SendMessageToTopic(RskPayload) returns (Void);
 
     //Update RSK Address after invitation
     rpc UpdateAddress(RskAddress) returns (Void);
@@ -76,6 +76,12 @@ message Msg {
 //Message used to publish a message in a specific topic
 message PublishPayload {
     Channel topic = 1;
+    Msg message = 2;
+}
+
+//Message used to publish a message in a rsk address
+message RskPayload {
+    RskAddress address = 1;
     Msg message = 2;
 }
 

--- a/src/protos/api.proto
+++ b/src/protos/api.proto
@@ -43,7 +43,7 @@ service CommunicationsApi {
     rpc CloseTopic (Channel) returns (Void);
 
     //Send Message to Specified Topic
-    rpc SendMessageToTopic(RskPayload) returns (Void);
+    rpc SendMessageToTopic(PublishPayload) returns (Void);
 
     //Update RSK Address after invitation
     rpc UpdateAddress(RskAddress) returns (Void);
@@ -76,12 +76,6 @@ message Msg {
 //Message used to publish a message in a specific topic
 message PublishPayload {
     Channel topic = 1;
-    Msg message = 2;
-}
-
-//Message used to publish a message in a rsk address
-message RskPayload {
-    RskAddress address = 1;
     Msg message = 2;
 }
 


### PR DESCRIPTION
Changes:
- Remove initialDelay from retry calls
- Adjust delay to a little more that 1 second
- Remove unidomatic Promise handling
- Fix getKey function returning error instead of throwing it