### PR TITLE
MultiRSK Feature

### DIFF
--- a/src/api-server.ts
+++ b/src/api-server.ts
@@ -442,7 +442,7 @@ async function subscribeToRoom(roomName: string): Promise<any> {
                 streamConnectionTopic.get(roomName)?.get(payload.to)?.write({
                     channelNewData: {
                         from: message.from,
-                        data: Buffer.from(JSON.stringify(payload.message)),
+                        data: Buffer.from(JSON.stringify(payload.content)),
                         nonce: message.seqno,
                         channel: channels
                     }
@@ -483,7 +483,7 @@ async function publishToRoom(roomName: string, message: string, to: string): Pro
     else {
         const room = subscriptions.get(roomName);
         //TODO ADD FROM
-        await room?.broadcast({ message: message, to: to});
+        await room?.broadcast({ content: message, to});
     }
 
     return status;

--- a/src/api-server.ts
+++ b/src/api-server.ts
@@ -113,10 +113,8 @@ function subscribe(parameters: any, callback: any): void {
 */
 async function publish(parameters: any, callback: any): Promise<void> {
     //TODO if there's no active stream the server should warn the user
-    const sender = "111" //GET FROM metada
-
     console.log(`publishing ${parameters.request.message.payload} in topic ${parameters.request.topic.channelId} `)
-    const status: any = await publishToRoom(parameters.request.topic.channelId, parameters.request.message.payload,parameters.request.topic.channelId,sender);
+    const status: any = await publishToRoom(parameters.request.topic.channelId, parameters.request.message.payload,parameters.request.topic.channelId);
 
     callback(status, {});
 }
@@ -330,19 +328,17 @@ async function closeTopicWithRskAddress({request: subscriber}: any, callback: an
 }
 
 async function sendMessageToTopic(parameters: any, callback: any): Promise<void> {
-    console.log(`sendMessageToTopic ${parameters} `)
-    const senderAddress = "111"; //TODO IDENTIFY RSKADDRESS WITH METADATA
-    const status = await publishToRoom(parameters.request.topic.channelId, parameters.request.message.payload,parameters.request.topic.channelId, senderAddress);
+    console.log(`sendMessageToTopic ${parameters} `)    
+    const status = await publishToRoom(parameters.request.topic.channelId, parameters.request.message.payload,parameters.request.topic.channelId);
 
     callback(status, {});
 }
 
 async function sendMessageToRskAddress({request}: any, callback: any): Promise<void> {
     console.log(`sendMessageToRskAddress ${JSON.stringify(request)}`)
-    const senderAddress = "111"; //TODO IDENTIFY RSKADDRESS WITH METADATA
     const {receiver: {address}, message: {payload}} = request;
     const topic = await dht.getPeerIdByRskAddress(address);
-    const status = await publishToRoom(topic, payload,address,senderAddress);
+    const status = await publishToRoom(topic, payload,address);
     callback(status, {});
 }
 
@@ -484,7 +480,7 @@ async function subscribeToRoom(roomName: string): Promise<any> {
 
 }
 
-async function publishToRoom(roomName: string, message: string, to: string,from: string): Promise<any> {
+async function publishToRoom(roomName: string, message: string, to: string): Promise<any> {
 
     let status: any = null;
 
@@ -496,7 +492,8 @@ async function publishToRoom(roomName: string, message: string, to: string,from:
     }
     else {
         const room = subscriptions.get(roomName);
-        await room?.broadcast({ message: message, to: to, from: from});
+        //TODO ADD FROM
+        await room?.broadcast({ message: message, to: to});
     }
 
     return status;

--- a/src/api-server.ts
+++ b/src/api-server.ts
@@ -1,6 +1,6 @@
 /* eslint no-console: 0 */
 import config, { has } from 'config'
-import { Room, createLibP2P, Message, DirectChat, DirectMessage } from '@rsksmart/rif-communications-pubsub'
+import { Room, createLibP2P, Message, DirectChat, DirectMessage, JsonSerializable } from '@rsksmart/rif-communications-pubsub'
 import PeerId from 'peer-id'
 import chalk from 'chalk'
 import { inspect } from 'util'
@@ -16,6 +16,7 @@ import { retry } from '@lifeomic/attempt';
 import {isValidPeerId} from "./peer-utils";
 import DhtService from "./service/dht";
 import EncodingService from "./service/encoding";
+import { JsonObject } from '@rsksmart/rif-communications-pubsub/types/definitions'
 
 
 var PROTO_PATH = __dirname + '/protos/api.proto';
@@ -446,16 +447,13 @@ async function subscribeToRoom(roomName: string): Promise<any> {
 
             console.log("roomName",roomName)
             if (streamConnectionTopic.get(roomName) !== undefined ) {
-                //Obtengo la lista de map《rsk,write》
-                //Itero hasta obtener el rsk que busco y hago get de ese elemento
-                //Le ejecuto un write solo a el.
                 for (let key of streamConnectionTopic.get(roomName).keys()) {
-                    console.log(message)
-                    if (key === message.data) {
+                    const payload = message.data as JsonObject
+                    if (key === payload.to) {
                         streamConnectionTopic.get(roomName).get(key).write({
                             channelNewData: {
                                 from: message.from,
-                                data: Buffer.from(JSON.stringify(message.data)),
+                                data: Buffer.from(JSON.stringify(payload.message)),
                                 nonce: message.seqno,
                                 channel: channels
                             }


### PR DESCRIPTION
Added MultiRSK feature for PubSub
When a message is published it's intended receiver is added to the message payload, and upon inspection of the topic, it multiplexed it according to the rskaddress of the clients.

For example we have 3 nodes with address 1,2,3 
1 and 2 are subscribed to Node A
3 is subscribed to Node B
If a message is sent to Address 1, only 1 should receive this message, even though they use the same underlying peerId topic.