### PR TITLE
bugfix/RIFCM-57/locate-peer-id-wrong-message

### DIFF
--- a/src/api/CommunicationsApiImpl.ts
+++ b/src/api/CommunicationsApiImpl.ts
@@ -98,7 +98,7 @@ class CommunicationsApiImpl implements CommunicationsApi {
             const address = await this.dht.getPeerIdByRskAddress(parameters.request.address);
             response = {address: address};
         } catch (e) {
-            status = {code: grpc.status.UNKNOWN, message: e.message}
+            status = {code: grpc.status.NOT_FOUND, message: "not found"}
         }
 
 


### PR DESCRIPTION
Fix locatePeerId message when peer was not found