### PR TITLE
Fix errors being sent as messages in grpc api

### DIFF
--- a/src/api/CommunicationsApiImpl.ts
+++ b/src/api/CommunicationsApiImpl.ts
@@ -49,7 +49,7 @@ class CommunicationsApiImpl implements CommunicationsApi {
             callback(null, {});
         } catch (error) {
             console.log(error);
-            callback({code: grpc.status.NOT_FOUND, message: `not subscribed to ${subscription.topic.address}` });
+            callback({code: grpc.status.NOT_FOUND, message: `not subscribed to ${subscription.topic.address}`});
         }
     }
 
@@ -110,14 +110,10 @@ class CommunicationsApiImpl implements CommunicationsApi {
             const topic = peer.createTopic(call.request.topic.address);
             topic?.subscribe(call.request.subscriber.address, call)
         } catch (e) {
-            call.write({
-                subscribeError: {
-                    channel: {
-                        channelId: ""
-                    },
-                    reason: e.message
-                }
-            });
+            call.emit('error', {
+                code: grpc.status.UNKNOWN,
+                message: e.message
+            })
         }
     }
 
@@ -137,10 +133,9 @@ class CommunicationsApiImpl implements CommunicationsApi {
                 }
             });
         } catch (e) {
-            call.write({
-                subscribeError: {
-                    reason: `Address ${call.request.topic.address} not found`
-                }
+            call.emit('error', {
+                code: grpc.status.NOT_FOUND,
+                message: `Address ${call.request.topic.address} not found`
             })
         }
     }
@@ -185,7 +180,7 @@ class CommunicationsApiImpl implements CommunicationsApi {
         console.log(`publishing ${parameters.request.message.payload} in topic ${parameters.request.topic.channelId} `)
         const peer = this.peerService.create(parameters.request.topic.channelId);
         peer.publish({content: parameters.request.message.payload});
-        callback(null,{});
+        callback(null, {});
     }
 
     async sendMessage(parameters: any, callback: any): Promise<void> {

--- a/src/api/CommunicationsApiImpl.ts
+++ b/src/api/CommunicationsApiImpl.ts
@@ -113,7 +113,8 @@ class CommunicationsApiImpl implements CommunicationsApi {
             call.emit('error', {
                 code: grpc.status.UNKNOWN,
                 message: e.message
-            })
+            });
+            call.end();
         }
     }
 
@@ -136,7 +137,8 @@ class CommunicationsApiImpl implements CommunicationsApi {
             call.emit('error', {
                 code: grpc.status.NOT_FOUND,
                 message: `Address ${call.request.topic.address} not found`
-            })
+            });
+            call.end();
         }
     }
 


### PR DESCRIPTION
Changes:
- Errors in streams were being sent as messages. They have been replaced by actual GRPC errors